### PR TITLE
Update isValidAddress to return true for payment codes (bip47.Wallet).

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.bitcoincashj</groupId>
         <artifactId>bitcoincashj-parent</artifactId>
-        <version>0.14.5-bip47.2</version>
+        <version>0.14.5-bip47.3</version>
     </parent>
 
     <artifactId>bitcoincashj-core</artifactId>

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -80,7 +80,7 @@ public class VersionMessage extends Message {
     public boolean relayTxesBeforeFilter;
 
     /** The version of this library release, as a string. */
-    public static final String BITCOINJ_VERSION = "0.14.5-bip47.2";
+    public static final String BITCOINJ_VERSION = "0.14.5-bip47.3";
     /** The value that is prepended to the subVer field of this application. */
     public static final String LIBRARY_SUBVER = "/bitcoincashj:" + BITCOINJ_VERSION + "/";
 

--- a/core/src/main/java/org/bitcoinj/wallet/bip47/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/bip47/Wallet.java
@@ -711,7 +711,15 @@ public class Wallet {
         return Address.fromBase58(getNetworkParameters(), addr);
     }
 
+    /** <p>Returns true if the given address is a valid payment code or a valid address in the
+     * wallet's blockchain network.</p> */
     public boolean isValidAddress(String address) {
+        try {
+            PaymentCode paymentCode = new PaymentCode(address);
+            return true;
+        } catch (AddressFormatException e){
+        }
+
         try {
             Address.fromBase58(getNetworkParameters(), address);
             return true;

--- a/core/src/test/java/org/bitcoinj/wallet/bip47/Bip47PaymentCodeTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/bip47/Bip47PaymentCodeTest.java
@@ -1,0 +1,46 @@
+package org.bitcoinj.wallet.bip47;
+
+import org.bitcoinj.core.AddressFormatException;
+import org.bitcoinj.crypto.bip47.Account;
+import org.bitcoinj.params.MainNetParams;
+import org.junit.Test;
+
+import static org.bitcoinj.core.Utils.HEX;
+import static org.junit.Assert.assertEquals;
+
+public class Bip47PaymentCodeTest {
+    private final String ALICE_PAYMENT_CODE_V1 = "PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA";
+    private final String ALICE_NOTIFICATION_ADDRESS = "1JDdmqFLhpzcUwPeinhJbUPw4Co3aWLyzW";
+    private final String ALICE_NOTIFICATION_TESTADDRESS = "mxjb4tLKWrRsG3sGSMfgRPcFvCPkVgM4td";
+
+    @Test
+    public void pubKeyDeriveTests(){
+
+        PaymentCode alice = new PaymentCode(ALICE_PAYMENT_CODE_V1);
+        Account acc = new Account(MainNetParams.get(), ALICE_PAYMENT_CODE_V1);
+
+        byte[] alice0th = alice.addressAt(MainNetParams.get(),0).getPubKey();
+        byte[] acc0th = acc.getNotificationKey().getPubKey();
+
+        byte[] alice1st = alice.addressAt(MainNetParams.get(),1).getPubKey();
+        byte[] acc1st = acc.keyAt(1).getPubKey();
+
+        assertEquals(HEX.encode(alice0th), HEX.encode(acc0th));
+        assertEquals(HEX.encode(alice1st), HEX.encode(acc1st));
+    }
+
+    @Test(expected = AddressFormatException.class)
+    public void invalidPaymentCodeTest1(){
+        PaymentCode invalid = new PaymentCode("XXXTJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA");
+    }
+
+    @Test(expected = AddressFormatException.class)
+    public void invalidPaymentCodeTest2(){
+        PaymentCode invalid = new PaymentCode("");
+    }
+
+    @Test(expected = AddressFormatException.class)
+    public void invalidPaymentCodeTest3(){
+        new PaymentCode(ALICE_PAYMENT_CODE_V1.replace('x','y'));
+    }
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.bitcoincashj</groupId>
         <artifactId>bitcoincashj-parent</artifactId>
-        <version>0.14.5-bip47.2</version>
+        <version>0.14.5-bip47.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.bitcoincashj</groupId>
   <artifactId>bitcoincashj-parent</artifactId>
-  <version>0.14.5-bip47.2</version>
+  <version>0.14.5-bip47.3</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.bitcoincashj</groupId>
     <artifactId>bitcoincashj-parent</artifactId>
-    <version>0.14.5-bip47.2</version>
+    <version>0.14.5-bip47.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/wallettemplate/pom.xml
+++ b/wallettemplate/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.bitcoincashj</groupId>
         <artifactId>bitcoincashj-parent</artifactId>
-        <version>0.14.5-bip47.2</version>
+        <version>0.14.5-bip47.3</version>
     </parent>
 
     <artifactId>wallettemplate</artifactId>


### PR DESCRIPTION
Add Bip47PaymentCodeTest with tests to validate PaymentCode

Fixes trace:

```
W/System.err: org.bitcoinj.core.AddressFormatException: Missing prefix: PM8TJPhuqtLRaAgyW9dYXtTNDh6QcLK88jgFoRTTEoZLJKLKAXX1M92aj1a2U6KxPhHzYodHU6BeT11Dn15vjzNAXUnA2J45gEK6Nyda3j6ivNvwaZEG
W/System.err:     at org.bitcoinj.core.CashAddress.decode(CashAddress.java:301)
W/System.err:     at org.bitcoinj.wallet.bip47.Wallet.isValidAddress(Wallet.java:720)
```